### PR TITLE
Fix incorrect escape sequence in Is_punctuation character class in texcount

### DIFF
--- a/texcount.pl
+++ b/texcount.pl
@@ -578,7 +578,7 @@ sub Is_punctuation { return <<END;
 +utf8::Punctuation
 -0024\t0025
 -005c
--007b\007e
+-007b\t007e
 END
 }
 


### PR DESCRIPTION
## Fix a typo : -007b\007e => -007b\t007e that caused a bug using -all-nonspace-char option : 

> Can't find Unicode property definition "007be" in expansion of Is_punctuation in regex; marked by <-- HERE in m/([\p{Digit}\p{Is_alphabetic}\p{Is_punctuation} <-- HERE ]|\\['\"\`\~\^\=]([\p{Digit}\p{Is_alphabetic}\p{Is_punctuation}]|\{[\p{Digit}\p{Is_alphabetic}\p{Is_punctuation}]\})|\\(ae|AE|o|O|aa|AA|oe|OE|ss|alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lamda|mu|nu|xi|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega)(\{\}|\s+|\b))/ at C:/Users/UserName/AppData/Local/Programs/MiKTeX/scripts/texcount/texcount.pl line 1512.